### PR TITLE
Replace log.log functions with log.info to fix missing substitutions in 1.2.5

### DIFF
--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/FactionChat.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/FactionChat.java
@@ -103,13 +103,13 @@ public class FactionChat extends JavaPlugin {
         }
         reload();
         String version = Bukkit.getServer().getPluginManager().getPlugin(this.getName()).getDescription().getVersion();
-        log.log(Level.INFO, "{0}: Version: {1} Enabled.", new Object[]{this.getName(), version});
+        log.info(this.getName() + ": Version: " + version + " Enabled.");
 
     }
 
     @Override
     public void onDisable() {
-        log.log(Level.INFO, "{0}: disabled", this.getName());
+        log.info(this.getName() + ": disabled");
     }
 
     protected void loadMyNewConfig() {
@@ -648,7 +648,7 @@ public class FactionChat extends JavaPlugin {
             metrics.start();
         } catch (IOException e) {
             // Failed to submit the stats :-(
-            log.log(Level.INFO, "[{0}] Metrics: Failed to submit the stats", this.getName());
+            log.info("[" + this.getName() + "] Metrics: Failed to submit the stats");
         }
     }
 

--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/FactionChatListener.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/FactionChatListener.java
@@ -167,7 +167,7 @@ public class FactionChatListener implements Listener {
                 }
 
                 if (isFactionChat) {
-                    log.log(Level.INFO, "[FactionChat] {0}|{1}: {2}", new Object[]{chatmode, talkingPlayer.getName(), msg});
+                    log.info("[FactionChat] " + chatmode + "|" + talkingPlayer.getName() + ": " + msg);
                     return setCancelled;
                 }
 
@@ -196,7 +196,7 @@ public class FactionChatListener implements Listener {
                 setCancelled = true;
             }
 
-            log.log(Level.INFO, "[FactionChat] {0}|{1}: {2}", new Object[]{chatmode, talkingPlayer.getName(), msg});
+            log.info("[FactionChat] " + chatmode + "|" + talkingPlayer.getName() + ": " + msg);
         } else {
             if (ChatMode.mutePublicOptionEnabled && !talkingPlayer.hasPermission("FactionChat.mutebypass")) {
                 for (final Player player : plugin.getServer().getOnlinePlayers()) {

--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/FactionChatListener2.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/FactionChatListener2.java
@@ -138,7 +138,7 @@ public class FactionChatListener2 implements Listener {
                 }
 
                 if (isFactionChat) {
-                    log.log(Level.INFO, "[FactionChat] {0}|{1}: {2}", new Object[]{chatmode, talkingPlayer.getName(), msg});
+                    log.info("[FactionChat] " + chatmode + "|" + talkingPlayer.getName() + ": " + msg);
                     return;
                 }
 
@@ -168,7 +168,7 @@ public class FactionChatListener2 implements Listener {
                 event.setCancelled(true);
             }
 
-            log.log(Level.INFO, "[FactionChat] {0}|{1}: {2}", new Object[]{chatmode, talkingPlayer.getName(), msg});
+            log.info("[FactionChat] " + chatmode + "|" + talkingPlayer.getName() + ": " + msg);
         }
         else
         {


### PR DESCRIPTION
I do not know if this bug is actually in newer versions of bukkit but it affects 1.2.5 (Tekkit Classic).  Should be forwards compatible as log.LEVEL() is referenced when setting up loggers for bukkit and I've never seen log.log() used before.
