### PR TITLE
Introduce ChatMode enum

### DIFF
--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/API/BanManagerAPI.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/API/BanManagerAPI.java
@@ -7,6 +7,7 @@ package nz.co.lolnet.james137137.FactionChat.API;
 
 import nz.co.lolnet.james137137.FactionChat.API.Event.FactionChatPlayerChatEvent;
 import nz.co.lolnet.james137137.FactionChat.FactionChat;
+import nz.co.lolnet.james137137.FactionChat.ChatModeType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -26,7 +27,7 @@ public class BanManagerAPI implements Listener {
 
     @EventHandler
     public void onPlayerChat(FactionChatPlayerChatEvent event) {
-        if (!event.getChatMode().equalsIgnoreCase("public") && isMuted(event.getPlayer())) {
+        if (event.getChatMode() != ChatModeType.PUBLIC && isMuted(event.getPlayer())) {
             event.setCancelled(true);
         }
     }

--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/API/Event/FactionChatPlayerChatEvent.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/API/Event/FactionChatPlayerChatEvent.java
@@ -8,6 +8,7 @@ package nz.co.lolnet.james137137.FactionChat.API.Event;
 import java.util.Set;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import nz.co.lolnet.james137137.FactionChat.ChatModeType;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
@@ -21,7 +22,7 @@ public class FactionChatPlayerChatEvent extends PlayerEvent implements Cancellab
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     Player player;
-    private String chatMode;
+    private ChatModeType chatMode;
     private String message;
     Set<Player> recipients;
 
@@ -31,7 +32,7 @@ public class FactionChatPlayerChatEvent extends PlayerEvent implements Cancellab
     }
     
 
-    public FactionChatPlayerChatEvent(Player talkingPlayer, String chatmode, String msg, Set<Player> recipients) {
+    public FactionChatPlayerChatEvent(Player talkingPlayer, ChatModeType chatmode, String msg, Set<Player> recipients) {
         super(talkingPlayer);
         this.player = talkingPlayer;
         this.chatMode = chatmode;
@@ -58,7 +59,7 @@ public class FactionChatPlayerChatEvent extends PlayerEvent implements Cancellab
         cancel = bln;
     }
 
-    public String getChatMode() {
+    public ChatModeType getChatMode() {
         return chatMode;
     }
 
@@ -74,7 +75,7 @@ public class FactionChatPlayerChatEvent extends PlayerEvent implements Cancellab
         return recipients;
     }
 
-    public void setChatMode(String chatMode) {
+    public void setChatMode(ChatModeType chatMode) {
         this.chatMode = chatMode;
     }
 

--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/API/FactionChatAPI.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/API/FactionChatAPI.java
@@ -9,6 +9,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import nz.co.lolnet.james137137.FactionChat.API.chat.ChatFilter;
 import nz.co.lolnet.james137137.FactionChat.ChatMode;
+import nz.co.lolnet.james137137.FactionChat.ChatModeType;
 import nz.co.lolnet.james137137.FactionChat.FactionChat;
 import nz.co.lolnet.james137137.FactionChat.PrefixAndSuffix.PrefixAndSuffix;
 import org.bukkit.Location;
@@ -99,7 +100,7 @@ public class FactionChatAPI {
         return factionChat.factionsAPI.getFactionName(player);
     }
 
-    public static String getChatMode(Player player) {
+    public static ChatModeType getChatMode(Player player) {
         return ChatMode.getChatMode(player);
     }
 
@@ -109,15 +110,15 @@ public class FactionChatAPI {
 
     public static boolean isFactionChatMessage(org.bukkit.event.player.AsyncPlayerChatEvent event) {
 
-        String chatmode = ChatMode.getChatMode(event.getPlayer());
-        return !chatmode.equalsIgnoreCase("PUBLIC");
+        ChatModeType chatmode = ChatMode.getChatMode(event.getPlayer());
+        return chatmode != ChatModeType.PUBLIC;
     }
 
     @Deprecated
     public static boolean isFactionChatMessage(org.bukkit.event.player.PlayerChatEvent event) {
 
-        String chatmode = ChatMode.getChatMode(event.getPlayer());
-        return !chatmode.equalsIgnoreCase("PUBLIC");
+        ChatModeType chatmode = ChatMode.getChatMode(event.getPlayer());
+        return chatmode != ChatModeType.PUBLIC;
     }
 
     public static double getDistance(Player playerA, Player playerB) {

--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/ChatChannel.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/ChatChannel.java
@@ -4,6 +4,7 @@ import nz.co.lolnet.james137137.FactionChat.API.ChatFormat;
 import nz.co.lolnet.james137137.FactionChat.API.FactionChatAPI;
 import nz.co.lolnet.james137137.FactionChat.API.EssentialsAPI;
 import nz.co.lolnet.james137137.FactionChat.FactionsAPI.MyRel;
+import nz.co.lolnet.james137137.FactionChat.ChatModeType;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -331,7 +332,7 @@ public class ChatChannel {
 
             if (!ChatMode.IsPlayerMutedTarget(myPlayer, player) && (relationship == MyRel.ENEMY
                     || sSenderFaction.equalsIgnoreCase(FactionChat.factionsAPI.getFactionName(player)) || FactionChat.factionsAPI.getFactionName(myPlayer).equalsIgnoreCase(sSenderFaction))
-                    && myPlayer.hasPermission("FactionChat.EnemyChat") && !FactionChat.factionsAPI.isFactionless(myPlayer) && ChatMode.getChatMode(myPlayer).equals("ENEMY")) {
+                    && myPlayer.hasPermission("FactionChat.EnemyChat") && !FactionChat.factionsAPI.isFactionless(myPlayer) && ChatMode.getChatMode(myPlayer) == ChatModeType.ENEMY) {
                 if (FactionChatAPI.canReceiveChat(myPlayer)) {
                     myPlayer.sendMessage(normalMessage);
                 }
@@ -484,7 +485,7 @@ public class ChatChannel {
 
         for (Player myPlayer : Bukkit.getServer().getOnlinePlayers()) {
 
-            if (!ChatMode.IsPlayerMutedTarget(myPlayer, player) && FactionChatAPI.getPlayerRank(player).equals(Config.LeaderRank) && ChatMode.getChatMode(myPlayer).equals("LEADER")) {
+            if (!ChatMode.IsPlayerMutedTarget(myPlayer, player) && FactionChatAPI.getPlayerRank(player).equals(Config.LeaderRank) && ChatMode.getChatMode(myPlayer) == ChatModeType.LEADER) {
                 if (FactionChatAPI.canReceiveChat(myPlayer)) {
                     myPlayer.sendMessage(normalMessage);
                 }
@@ -544,7 +545,7 @@ public class ChatChannel {
         for (Player myPlayer : Bukkit.getServer().getOnlinePlayers()) {
 
             if (!ChatMode.IsPlayerMutedTarget(myPlayer, player) && (FactionChatAPI.getPlayerRank(player).equals(Config.LeaderRank)
-                    || FactionChatAPI.getPlayerRank(player).equals(Config.OfficerRank)) && ChatMode.getChatMode(myPlayer).equals("OFFICER")) {
+                    || FactionChatAPI.getPlayerRank(player).equals(Config.OfficerRank)) && ChatMode.getChatMode(myPlayer) == ChatModeType.OFFICER) {
                 if (FactionChatAPI.canReceiveChat(myPlayer)) {
                     myPlayer.sendMessage(normalMessage);
                 }

--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/ChatMode.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/ChatMode.java
@@ -26,7 +26,7 @@ public class ChatMode {
     protected static HashMap<String, List<String>> playerMuteList = new HashMap();
     protected static HashMap<String, Boolean> LocalChat = new HashMap();
     private static long chatTimeLimit;
-    private static HashMap<String, String> playerChatMode = new HashMap();
+    private static HashMap<String, ChatModeType> playerChatMode = new HashMap<>();
 
     protected static void initialize(FactionChat plugin) {
         FileConfiguration config = plugin.getConfig();
@@ -41,7 +41,7 @@ public class ChatMode {
         OfficerName = new FactionChatMessage(null, config.getString("message.ChatModeChange.OfficerChat"), true).toString();
         mutePublicOptionEnabled = config.getBoolean("AllowPublicMuteCommand");
         chatTimeLimit = config.getLong("ChatLimit");
-        playerChatMode = new HashMap();
+        playerChatMode = new HashMap<>();
     }
 
     public static void cleanup(Player player) {
@@ -84,12 +84,12 @@ public class ChatMode {
 
     }
 
-    public static String getChatMode(Player player) {
+    public static ChatModeType getChatMode(Player player) {
         String playerName = player.getName();
-        String chatMode = (String) getPlayerChatMode(playerName);
+        ChatModeType chatMode = getPlayerChatMode(playerName);
         if (chatMode == null) {
-            setPlayerChatMode(playerName, "PUBLIC");
-            return "PUBLIC";
+            setPlayerChatMode(playerName, ChatModeType.PUBLIC);
+            return ChatModeType.PUBLIC;
         }
         return chatMode;
     }
@@ -109,7 +109,7 @@ public class ChatMode {
     protected static void SetNewChatMode(Player player) {
         String playerName = player.getName();
         playerMutePublicMode.put(player.getName(), false);
-        setPlayerChatMode(playerName, "PUBLIC");
+        setPlayerChatMode(playerName, ChatModeType.PUBLIC);
 
         if (player.hasPermission("FactionChat.spy") && Config.spyModeOnByDefault) {
             spyMode.put(playerName, true);
@@ -121,15 +121,15 @@ public class ChatMode {
 
     protected static void NextChatMode(Player player) {
         String playerName = player.getName();
-        String currentChatMode = (String) getPlayerChatMode(playerName);
-        if (Config.PublicMuteDefault && !currentChatMode.equalsIgnoreCase("PUBLIC")) {
+        ChatModeType currentChatMode = getPlayerChatMode(playerName);
+        if (Config.PublicMuteDefault && currentChatMode != ChatModeType.PUBLIC) {
             if (!ChatMode.IsPublicMuted(player)) {
                 ChatMode.MutePublicOption(player);
             }
         }
         if (FactionChat.FactionsEnable) {
-            if (currentChatMode.equalsIgnoreCase("PUBLIC")) {
-                setPlayerChatMode(playerName, "ALLY");
+            if (currentChatMode == ChatModeType.PUBLIC) {
+                setPlayerChatMode(playerName, ChatModeType.ALLY);
                 if (Config.AllyChatEnable && player.hasPermission("FactionChat.AllyChat")) {
 
                     player.sendMessage(Config.messageNewChatMode + AllyName);
@@ -137,8 +137,8 @@ public class ChatMode {
                 }
 
             }
-            if (currentChatMode.equalsIgnoreCase("ALLY") && player.hasPermission("FactionChat.FactionChat")) {
-                setPlayerChatMode(playerName, "FACTION");
+            if (currentChatMode == ChatModeType.ALLY && player.hasPermission("FactionChat.FactionChat")) {
+                setPlayerChatMode(playerName, ChatModeType.FACTION);
                 if (Config.FactionChatEnable) {
                     player.sendMessage(Config.messageNewChatMode + FactionName);
                     return;
@@ -146,8 +146,8 @@ public class ChatMode {
 
             }
 
-            if (currentChatMode.equalsIgnoreCase("FACTION") && player.hasPermission("FactionChat.TruceChat")) {
-                setPlayerChatMode(playerName, "TRUCE");
+            if (currentChatMode == ChatModeType.FACTION && player.hasPermission("FactionChat.TruceChat")) {
+                setPlayerChatMode(playerName, ChatModeType.TRUCE);
                 if (Config.TruceChatEnable) {
                     player.sendMessage(Config.messageNewChatMode + TruceName);
                     return;
@@ -155,8 +155,8 @@ public class ChatMode {
 
             }
 
-            if (currentChatMode.equalsIgnoreCase("TRUCE") && player.hasPermission("FactionChat.TruceChat") && player.hasPermission("FactionChat.AllyChat")) {
-                setPlayerChatMode(playerName, "ALLY&TRUCE");
+            if (currentChatMode == ChatModeType.TRUCE && player.hasPermission("FactionChat.TruceChat") && player.hasPermission("FactionChat.AllyChat")) {
+                setPlayerChatMode(playerName, ChatModeType.ALLY_TRUCE);
                 if (Config.AllyTruceChatEnable) {
                     player.sendMessage(Config.messageNewChatMode + AllyTruceName);
                     return;
@@ -165,7 +165,7 @@ public class ChatMode {
             }
         }
 
-        setPlayerChatMode(playerName, "PUBLIC");
+        setPlayerChatMode(playerName, ChatModeType.PUBLIC);
         player.sendMessage(Config.messageNewChatMode + PublicName);
         if (ChatMode.IsPublicMuted(player)) {
             LocalChat.put(playerName, false);
@@ -177,7 +177,7 @@ public class ChatMode {
     protected static void setChatMode(Player player, String input) {
         String playerName = player.getName();
         if (input.equalsIgnoreCase("PUBLIC") || input.equalsIgnoreCase("P")) {
-            setPlayerChatMode(playerName, "PUBLIC");
+            setPlayerChatMode(playerName, ChatModeType.PUBLIC);
             playerMutePublicMode.put(playerName, false);
             LocalChat.put(playerName, false);
             player.sendMessage(Config.messageNewChatMode + PublicName);
@@ -190,7 +190,7 @@ public class ChatMode {
                 if (!Config.AllyTruceChatEnable) {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 } else if (player.hasPermission("FactionChat.AllyChat") && player.hasPermission("FactionChat.TruceChat")) {
-                    setPlayerChatMode(playerName, "ALLY&TRUCE");
+                    setPlayerChatMode(playerName, ChatModeType.ALLY_TRUCE);
                     player.sendMessage(Config.messageNewChatMode + AllyTruceName);
                 }
 
@@ -199,7 +199,7 @@ public class ChatMode {
                 if (!Config.AllyChatEnable) {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 } else if (player.hasPermission("FactionChat.AllyChat")) {
-                    setPlayerChatMode(playerName, "ALLY");
+                    setPlayerChatMode(playerName, ChatModeType.ALLY);
                     player.sendMessage(Config.messageNewChatMode + AllyName);
                 }
 
@@ -208,7 +208,7 @@ public class ChatMode {
                 if (!Config.TruceChatEnable) {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 } else if (player.hasPermission("FactionChat.TruceChat")) {
-                    setPlayerChatMode(playerName, "TRUCE");
+                    setPlayerChatMode(playerName, ChatModeType.TRUCE);
                     player.sendMessage(Config.messageNewChatMode + TruceName);
                 }
 
@@ -217,7 +217,7 @@ public class ChatMode {
                 if (!Config.FactionChatEnable) {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 } else if (player.hasPermission("FactionChat.FactionChat")) {
-                    setPlayerChatMode(playerName, "FACTION");
+                    setPlayerChatMode(playerName, ChatModeType.FACTION);
                     player.sendMessage(Config.messageNewChatMode + FactionName);
                 }
 
@@ -228,7 +228,7 @@ public class ChatMode {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                     return;
                 }
-                setPlayerChatMode(playerName, "ENEMY");
+                setPlayerChatMode(playerName, ChatModeType.ENEMY);
                 player.sendMessage(Config.messageNewChatMode + EnermyName);
 
             } else if (FactionChatAPI.getPlayerRank(player).equals(Config.LeaderRank)
@@ -238,7 +238,7 @@ public class ChatMode {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                     return;
                 }
-                setPlayerChatMode(playerName, "LEADER");
+                setPlayerChatMode(playerName, ChatModeType.LEADER);
                 player.sendMessage(Config.messageNewChatMode + LeaderName);
 
             } else if ((FactionChatAPI.getPlayerRank(player).equals(Config.LeaderRank)
@@ -249,7 +249,7 @@ public class ChatMode {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                     return;
                 }
-                setPlayerChatMode(playerName, "OFFICER");
+                setPlayerChatMode(playerName, ChatModeType.OFFICER);
                 player.sendMessage(Config.messageNewChatMode + OfficerName);
 
             }
@@ -265,7 +265,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "VIP");
+            setPlayerChatMode(playerName, ChatModeType.VIP);
             player.sendMessage(Config.messageNewChatMode + ChatColor.GOLD + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.UserAssistantChat") || FactionChat.isDebugger(player.getName()))
                 && (input.equalsIgnoreCase("UA") || input.equalsIgnoreCase("UserAssistant"))) {
@@ -273,7 +273,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "UserAssistant");
+            setPlayerChatMode(playerName, ChatModeType.USERASSISTANT);
             player.sendMessage(Config.messageNewChatMode + ChatColor.DARK_PURPLE + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.JrModChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("JrMOD")) {
@@ -281,7 +281,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "JrMOD");
+            setPlayerChatMode(playerName, ChatModeType.JRMOD);
             player.sendMessage(Config.messageNewChatMode + ChatColor.BLUE + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.ModChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("MOD")) {
@@ -289,7 +289,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "MOD");
+            setPlayerChatMode(playerName, ChatModeType.MOD);
             player.sendMessage(Config.messageNewChatMode + ChatColor.BLUE + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.SrModChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("SrMOD")) {
@@ -297,7 +297,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "SrMOD");
+            setPlayerChatMode(playerName, ChatModeType.SRMOD);
             player.sendMessage(Config.messageNewChatMode + ChatColor.BLUE + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.JrAdminChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("JrADMIN")) {
@@ -305,7 +305,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "JrADMIN");
+            setPlayerChatMode(playerName, ChatModeType.JRADMIN);
             player.sendMessage(Config.messageNewChatMode + ChatColor.DARK_RED + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.AdminChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("ADMIN")) {
@@ -313,7 +313,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "ADMIN");
+            setPlayerChatMode(playerName, ChatModeType.ADMIN);
             player.sendMessage(Config.messageNewChatMode + ChatColor.DARK_RED + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.spy") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("SPY")) {
@@ -337,7 +337,7 @@ public class ChatMode {
     protected static void setChatMode(Player player, String input, CommandSender sender) {
         String playerName = player.getName();
         if (input.equalsIgnoreCase("PUBLIC") || input.equalsIgnoreCase("P")) {
-            setPlayerChatMode(playerName, "PUBLIC");
+            setPlayerChatMode(playerName, ChatModeType.PUBLIC);
             playerMutePublicMode.put(playerName, false);
             player.sendMessage(Config.messageNewChatMode + PublicName);
             return;
@@ -349,7 +349,7 @@ public class ChatMode {
                 if (!Config.AllyTruceChatEnable) {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 } else if (player.hasPermission("FactionChat.AllyChat")) {
-                    setPlayerChatMode(playerName, "ALLY&TRUCE");
+                    setPlayerChatMode(playerName, ChatModeType.ALLY_TRUCE);
                     player.sendMessage(Config.messageNewChatMode + AllyTruceName);
                 }
 
@@ -358,7 +358,7 @@ public class ChatMode {
                 if (!Config.AllyChatEnable) {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 } else if (player.hasPermission("FactionChat.AllyChat")) {
-                    setPlayerChatMode(playerName, "ALLY");
+                    setPlayerChatMode(playerName, ChatModeType.ALLY);
                     player.sendMessage(Config.messageNewChatMode + AllyName);
                 }
 
@@ -367,7 +367,7 @@ public class ChatMode {
                 if (!Config.TruceChatEnable) {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 } else if (player.hasPermission("FactionChat.AllyChat")) {
-                    setPlayerChatMode(playerName, "TRUCE");
+                    setPlayerChatMode(playerName, ChatModeType.TRUCE);
                     player.sendMessage(Config.messageNewChatMode + TruceName);
                 }
 
@@ -376,7 +376,7 @@ public class ChatMode {
                 if (!Config.FactionChatEnable) {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 } else if (player.hasPermission("FactionChat.FactionChat")) {
-                    setPlayerChatMode(playerName, "FACTION");
+                    setPlayerChatMode(playerName, ChatModeType.FACTION);
                     player.sendMessage(Config.messageNewChatMode + FactionName);
                 }
 
@@ -387,7 +387,7 @@ public class ChatMode {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                     return;
                 }
-                setPlayerChatMode(playerName, "ENEMY");
+                setPlayerChatMode(playerName, ChatModeType.ENEMY);
                 player.sendMessage(Config.messageNewChatMode + EnermyName);
 
             } else if (FactionChatAPI.getPlayerRank(player).equals(Config.LeaderRank)
@@ -397,7 +397,7 @@ public class ChatMode {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                     return;
                 }
-                setPlayerChatMode(playerName, "LEADER");
+                setPlayerChatMode(playerName, ChatModeType.LEADER);
                 player.sendMessage(Config.messageNewChatMode + LeaderName);
 
             } else if ((FactionChatAPI.getPlayerRank(player).equals(Config.LeaderRank)
@@ -408,7 +408,7 @@ public class ChatMode {
                     player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                     return;
                 }
-                setPlayerChatMode(playerName, "OFFICER");
+                setPlayerChatMode(playerName, ChatModeType.OFFICER);
                 player.sendMessage(Config.messageNewChatMode + OfficerName);
 
             }
@@ -424,7 +424,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "UserAssistant");
+            setPlayerChatMode(playerName, ChatModeType.USERASSISTANT);
             player.sendMessage(Config.messageNewChatMode + ChatColor.DARK_PURPLE + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.JrModChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("JrMOD")) {
@@ -432,7 +432,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "JrMOD");
+            setPlayerChatMode(playerName, ChatModeType.JRMOD);
             player.sendMessage(Config.messageNewChatMode + ChatColor.BLUE + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.ModChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("MOD")) {
@@ -440,7 +440,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "MOD");
+            setPlayerChatMode(playerName, ChatModeType.MOD);
             player.sendMessage(Config.messageNewChatMode + ChatColor.BLUE + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.SrModChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("SrMOD")) {
@@ -448,7 +448,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "SrMOD");
+            setPlayerChatMode(playerName, ChatModeType.SRMOD);
             player.sendMessage(Config.messageNewChatMode + ChatColor.BLUE + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.JrAdminChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("JrADMIN")) {
@@ -456,7 +456,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "JrADMIN");
+            setPlayerChatMode(playerName, ChatModeType.JRADMIN);
             player.sendMessage(Config.messageNewChatMode + ChatColor.DARK_RED + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.AdminChat") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("ADMIN")) {
@@ -464,7 +464,7 @@ public class ChatMode {
                 player.sendMessage(ChatColor.RED + "Sorry this chat mode is disabled");
                 return;
             }
-            setPlayerChatMode(playerName, "ADMIN");
+            setPlayerChatMode(playerName, ChatModeType.ADMIN);
             player.sendMessage(Config.messageNewChatMode + ChatColor.DARK_RED + getPlayerChatMode(playerName));
         } else if ((player.hasPermission("FactionChat.spy") || FactionChat.isDebugger(player.getName()))
                 && input.equalsIgnoreCase("SPY")) {
@@ -476,10 +476,10 @@ public class ChatMode {
 
     protected static void fixPlayerNotInFaction(Player player) {
         String playerName = player.getName();
-        String chatMode = (String) getPlayerChatMode(playerName);
+        ChatModeType chatMode = getPlayerChatMode(playerName);
 
-        if (!chatMode.equalsIgnoreCase("PUBLIC")) {
-            setPlayerChatMode(playerName, "PUBLIC");
+        if (chatMode != ChatModeType.PUBLIC) {
+            setPlayerChatMode(playerName, ChatModeType.PUBLIC);
             playerMutePublicMode.put(playerName, false);
             player.sendMessage(Config.messageNewChatMode + PublicName);
         }
@@ -577,7 +577,7 @@ public class ChatMode {
         return false;
     }
 
-    public static String getPlayerChatMode(String playerName) {
+    public static ChatModeType getPlayerChatMode(String playerName) {
         return playerChatMode.get(playerName);
     }
 
@@ -585,7 +585,7 @@ public class ChatMode {
         playerChatMode.remove(playerName);
     }
 
-    public static void setPlayerChatMode(String playerName, String chatMode) {
+    public static void setPlayerChatMode(String playerName, ChatModeType chatMode) {
         playerChatMode.put(playerName, chatMode);
     }
 

--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/ChatModeType.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/ChatModeType.java
@@ -1,0 +1,96 @@
+package nz.co.lolnet.james137137.FactionChat;
+
+public enum ChatModeType {
+    PUBLIC,
+    FACTION,
+    ALLY,
+    TRUCE,
+    ALLY_TRUCE,
+    ENEMY,
+    LEADER,
+    OFFICER,
+    VIP,
+    USERASSISTANT,
+    JRMOD,
+    MOD,
+    SRMOD,
+    JRADMIN,
+    ADMIN;
+
+    public static ChatModeType fromInput(String input) {
+        if (input == null) {
+            return null;
+        }
+        String key = input.trim().toUpperCase();
+        switch (key) {
+            case "P":
+            case "PUBLIC":
+                return PUBLIC;
+            case "F":
+            case "FACTION":
+                return FACTION;
+            case "A":
+            case "ALLY":
+                return ALLY;
+            case "T":
+            case "TRUCE":
+                return TRUCE;
+            case "AT":
+            case "ALLYTRUCE":
+            case "ALLY_TRUCE":
+            case "ALLY&TRUCE":
+                return ALLY_TRUCE;
+            case "E":
+            case "ENEMY":
+                return ENEMY;
+            case "L":
+            case "LEADER":
+                return LEADER;
+            case "O":
+            case "OFFICER":
+                return OFFICER;
+            case "V":
+            case "VIP":
+                return VIP;
+            case "UA":
+            case "USERASSISTANT":
+            case "USER_ASSISTANT":
+                return USERASSISTANT;
+            case "JRMOD":
+                return JRMOD;
+            case "MOD":
+                return MOD;
+            case "SRMOD":
+                return SRMOD;
+            case "JRADMIN":
+                return JRADMIN;
+            case "ADMIN":
+                return ADMIN;
+            default:
+                key = key.replace("&", "_");
+                try {
+                    return ChatModeType.valueOf(key);
+                } catch (IllegalArgumentException e) {
+                    return null;
+                }
+        }
+    }
+
+    @Override
+    public String toString() {
+        switch (this) {
+            case ALLY_TRUCE:
+                return "ALLY&TRUCE";
+            case USERASSISTANT:
+                return "UserAssistant";
+            case JRMOD:
+                return "JrMOD";
+            case SRMOD:
+                return "SrMOD";
+            case JRADMIN:
+                return "JrADMIN";
+            default:
+                return name();
+        }
+    }
+}

--- a/src/main/java/nz/co/lolnet/james137137/FactionChat/FactionChatListener.java
+++ b/src/main/java/nz/co/lolnet/james137137/FactionChat/FactionChatListener.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
 import nz.co.lolnet.james137137.FactionChat.API.Event.FactionChatPlayerChatEvent;
+import nz.co.lolnet.james137137.FactionChat.ChatModeType;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -134,16 +135,16 @@ public class FactionChatListener implements Listener {
     private boolean onChat(Player talkingPlayer, String msg, Set<Player> recipients) {
         boolean success = false;
         
-        String chatmode = ChatMode.getChatMode(talkingPlayer);
+        ChatModeType chatmode = ChatMode.getChatMode(talkingPlayer);
         
-        FactionChatPlayerChatEvent event = new FactionChatPlayerChatEvent(talkingPlayer,chatmode,msg,recipients);
+        FactionChatPlayerChatEvent event = new FactionChatPlayerChatEvent(talkingPlayer, chatmode, msg, recipients);
         plugin.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled())
         {
             return false; //let other plugins decide to cancel or not
         }
         
-        if (!chatmode.equalsIgnoreCase("PUBLIC")) {
+        if (chatmode != ChatModeType.PUBLIC) {
             if (Config.limitWorldsChat) {
                 if (Config.limitWorldsChatDisableOther && Config.limitWorldsChatDisableReceive) {
                     for (Player recipient : recipients) {
@@ -156,32 +157,32 @@ public class FactionChatListener implements Listener {
             }
             boolean isFactionChat = false;
             if (plugin.FactionsEnable) {
-                if (chatmode.equalsIgnoreCase("ALLY&TRUCE")) {
+                if (chatmode == ChatModeType.ALLY_TRUCE) {
                     channel.fChatAT(talkingPlayer, msg);
                     success = true;
                     isFactionChat = true;
 
-                } else if (chatmode.equalsIgnoreCase("ENEMY")) {
+                } else if (chatmode == ChatModeType.ENEMY) {
                     channel.fChatE(talkingPlayer, msg);
                     success = true;
                     isFactionChat = true;
-                } else if (chatmode.equalsIgnoreCase("FACTION")) {
+                } else if (chatmode == ChatModeType.FACTION) {
                     channel.fChatF(talkingPlayer, msg);
                     success = true;
                     isFactionChat = true;
-                } else if (chatmode.equalsIgnoreCase("ALLY")) {
+                } else if (chatmode == ChatModeType.ALLY) {
                     channel.fChatA(talkingPlayer, msg);
                     success = true;
                     isFactionChat = true;
-                } else if (chatmode.equalsIgnoreCase("TRUCE")) {
+                } else if (chatmode == ChatModeType.TRUCE) {
                     channel.fChatTruce(talkingPlayer, msg);
                     success = true;
                     isFactionChat = true;
-                } else if (chatmode.equalsIgnoreCase("LEADER")) {
+                } else if (chatmode == ChatModeType.LEADER) {
                     channel.fChatLeader(talkingPlayer, msg);
                     success = true;
                     isFactionChat = true;
-                } else if (chatmode.equalsIgnoreCase("OFFICER")) {
+                } else if (chatmode == ChatModeType.OFFICER) {
                     channel.fChatOfficer(talkingPlayer, msg);
                     success = true;
                     isFactionChat = true;
@@ -194,25 +195,25 @@ public class FactionChatListener implements Listener {
 
             }
 
-            if (chatmode.equalsIgnoreCase("VIP")) {
+            if (chatmode == ChatModeType.VIP) {
                 otherChannel.VIPChat(talkingPlayer, msg);
                 success = true;
-            } else if (chatmode.equalsIgnoreCase("UserAssistant")) {
+            } else if (chatmode == ChatModeType.USERASSISTANT) {
                 otherChannel.userAssistantChat(talkingPlayer, msg);
                 success = true;
-            } else if (chatmode.equalsIgnoreCase("JrMOD")) {
+            } else if (chatmode == ChatModeType.JRMOD) {
                 otherChannel.jrModChat(talkingPlayer, msg);
                 success = true;
-            } else if (chatmode.equalsIgnoreCase("MOD")) {
+            } else if (chatmode == ChatModeType.MOD) {
                 otherChannel.modChat(talkingPlayer, msg);
                 success = true;
-            } else if (chatmode.equalsIgnoreCase("SrMOD")) {
+            } else if (chatmode == ChatModeType.SRMOD) {
                 otherChannel.SrModChat(talkingPlayer, msg);
                 success = true;
-            } else if (chatmode.equalsIgnoreCase("JrAdmin")) {
+            } else if (chatmode == ChatModeType.JRADMIN) {
                 otherChannel.JrAdminChat(talkingPlayer, msg);
                 success = true;
-            } else if (chatmode.equalsIgnoreCase("ADMIN")) {
+            } else if (chatmode == ChatModeType.ADMIN) {
                 otherChannel.adminChat(talkingPlayer, msg);
                 success = true;
             }


### PR DESCRIPTION
## Summary
- implement `ChatModeType` enum for chat modes
- refactor `ChatMode` logic to use the enum
- update listeners and APIs to compare enum values

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e3e5b38c83279616a2c7c0fede66